### PR TITLE
Devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version (use hirsuite or bionic on local arm64/Apple Silicon): hirsute, focal, bionic
+ARG VARIANT="hirsute"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+WORKDIR /dependencies
+RUN wget --progress=dot:giga https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
+
+WORKDIR /opt
+RUN tar xf /dependencies/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 \
+    && rm -rf gcc-arm-none-eabi-10-2020-q4-major-x86_64/share/doc
+
+ENV PATH="/opt/gcc-arm-none-eabi-10-2020-q4-major/bin:${PATH}"
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    build-essential \
+    cmake \
+    ninja-build \
+    cppcheck \
+    clang-tidy \
+    clang-format \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
+		// Use hirsute or bionic on local arm64/Apple Silicon.
+		"args": { "VARIANT": "focal" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vscode.cpptools",
+		"ms-vscode.cpptools-extension-pack"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": true
+}

--- a/README.md
+++ b/README.md
@@ -23,3 +23,53 @@ This is LVGL ported to [STM32F746G-DISCO](https://www.st.com/en/evaluation-tools
     * Open IAR workspace at `ide/iar/stm32f746_disco_lvgl.eww`
 3. Connect the Discovery board
 4. Build and run!
+
+# How to build using VSCode and Devcontainers
+
+## Prerequisits
+* [Visual Studio Code](https://code.visualstudio.com/Download)
+* [Visual Studio Code Extension : Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) 
+* [Docker Desktop](https://docs.docker.com/desktop/)
+
+## Using Devcontainers
+For the background to Microsoft's Development containers see [here](https://code.visualstudio.com/docs/remote/containers)
+
+At the project root, open the project using VSCode
+```
+$ code .
+```
+
+VSCode will then pop up a dialog:
+```
+Folder contains a Dev Container configuration file. Reopen folder to develop in a container
+```
+Select *Reopen in Container*
+
+First time through this will build a Docker image from scratch using `.devcontainer/Dockerfile` - this may take a couple of minutes as it includes downloading the `gcc-arm-none-eabi` toolset from `developer.arm.com`. This build is a one-off operation.
+
+Once VSCode has created the Docker image and launched the container, open a new Terminal window (using the VSCode menu). You are now working in an Ubuntu based envrionment.
+
+## To Build
+
+```
+$ cmake -S . -B build -G Ninja
+```
+
+```
+$ cmake --build build
+```
+
+This will create the artifact `build/lv_stm32f756.bin` that can be downloaded to the target board.
+
+To rebuild, simple repeat:
+```
+$ cmake --build build
+```
+
+If you add new files, then rerun:
+```
+$ cmake -S . -B build -G Ninja
+$ cmake --build build
+```
+
+


### PR DESCRIPTION
This branch adds Development container support using VSCode to the project.
using Devconatiner invokes a Docker container with all the required tools installed (gcc-arm ,make, etc.) for building the project in a repeatable way without requiring any tools installed locally (except VSCode and Docker desktop).
This works cross-platform (Win10, Linux, macOS) and makes starting with lvgl on the STM32F476 Discovery kit much simpler.