### PR TITLE
Updated CMake to generate compile_commands.json file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ include("ide/cmake/arm-none-eabi.cmake")
 # project name
 project(lv_stm32f746 C ASM)
 
+# Generate compile_commands.json file 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # select linker script
 set(LINKER_SCRIPT "LinkerScript.ld")
 


### PR DESCRIPTION
The compile_commands.json file is widely used by other tools, such a clang-tidy, cppcheck, etc.
It is a worthwhile addition to the build script when using CMake
See [CMAKE_EXPORT_COMPILE_COMMANDS](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html) for details.