### PR TITLE
Updated CMake to correctly use lvgl subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 /build
+
+# macOS
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,10 @@ FILE(GLOB_RECURSE HAL_Sources HAL_Driver/Src/*.c
     Utilities/STM32746G-Discovery/stm32746g_discovery.c
     Utilities/STM32746G-Discovery/stm32746g_discovery_sdram.c
 )
+FILE(GLOB_RECURSE LVGL_Sources CONFIGURE_DEPENDS hal_stm_lvgl/*.c)
 
-FILE(GLOB_RECURSE LVGL_Sources CONFIGURE_DEPENDS lvgl/src/*.c lv_examples/*.c hal_stm_lvgl/*.c)
+add_subdirectory(lvgl)
+add_subdirectory(lv_examples)
 
 add_definitions(
     -DSTM32
@@ -86,6 +88,8 @@ target_link_libraries(${PROJECT_NAME}
     -nodefaultlibs
     -Wl,--gc-sections
     m
+    lv_examples
+    lvgl
     # -nostdlib
 )
 


### PR DESCRIPTION
Removed the use of `GLOB_RECURSE` for **lvgl** and **lv_examples** and instead use
```
add_subdirectory(lvgl)
add_subdirectory(lv_examples)
```

as these have their own `CMakeLists.txt` files. Updated linker directive
```
target_link_libraries(${PROJECT_NAME}
    ...
    lv_examples
    lvgl
)
```