### PR TITLE
Generate .elf extension and update build.sh to use Ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,13 @@ target_link_libraries(${PROJECT_NAME}
     # -nostdlib
 )
 
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    SUFFIX .elf
+    LINK_DEPENDS "${LINKER_SCRIPTS}"
+)
+
 add_custom_target(${PROJECT_NAME}.bin ALL DEPENDS ${PROJECT_NAME})
 add_custom_command(TARGET ${PROJECT_NAME}.bin
-    COMMAND ${CMAKE_C_OBJCOPY} ARGS -O binary ${PROJECT_NAME} ${PROJECT_NAME}.bin)
+    COMMAND ${CMAKE_C_OBJCOPY} ARGS -O binary ${PROJECT_NAME}.elf ${PROJECT_NAME}.bin)
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY LINK_DEPENDS ${CMAKE_SOURCE_DIR}/${LINKER_SCRIPT})

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ done
 
 [[ -n $RESET && -d $BUILD_DIR ]] && rm -rf $BUILD_DIR
     
-$CMAKE -S . -B $BUILD_DIR --warn-uninitialized -Wno-dev -DCMAKE_BUILD_TYPE=$TYPE
+$CMAKE -S . -B $BUILD_DIR --warn-uninitialized -Wno-dev -DCMAKE_BUILD_TYPE=$TYPE -GNinja
 
 [[ -n $CLEAN ]] && $CMAKE --build $BUILD_DIR --target clean
 


### PR DESCRIPTION
The main application didn't have any extension - as good practice this should ideally be a `.elf` file, which is then used to `objcopy` to the `.bin` file.
Also updated the build script to use *Ninja* rather than *make*.