### PR TITLE
Updated CMake to use FetchContent as per lvgl guide

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,11 +7,6 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 WORKDIR /dependencies
 RUN wget --progress=dot:giga https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
 
-WORKDIR /opt
-RUN tar xf /dependencies/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 \
-    && rm -rf gcc-arm-none-eabi-10-2020-q4-major-x86_64/share/doc
-
-ENV PATH="/opt/gcc-arm-none-eabi-10-2020-q4-major/bin:${PATH}"
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
@@ -22,9 +17,15 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     cmake \
     ninja-build \
     libncurses5 \
+    lbzip2 \
     cppcheck \
     clang-tidy \
     clang-format \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 
+WORKDIR /opt
+RUN tar xf /dependencies/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 \
+    && rm -rf gcc-arm-none-eabi-10-2020-q4-major-x86_64/share/doc
+
+ENV PATH="/opt/gcc-arm-none-eabi-10-2020-q4-major/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
 		// Use hirsute or bionic on local arm64/Apple Silicon.
-		"args": { "VARIANT": "focal" }
+		"args": { "VARIANT": "hirsute" }
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined", "--net=host"],
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,39 @@
 cmake_minimum_required(VERSION 3.10)
+include(FetchContent)
+Set(FETCHCONTENT_QUIET FALSE)   # set to TRUE to suppress FetchContent progress
+
 include("ide/cmake/arm-none-eabi.cmake")
 # project name
-project(lv_stm32f746 C ASM)
+project(lv_stm32f746 C CXX ASM)
 
 # Generate compile_commands.json file 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+
+# Specify path to own LVGL config header
+set(LV_CONF_PATH
+    ${CMAKE_CURRENT_SOURCE_DIR}/lv_conf.h
+    CACHE STRING "" FORCE)
+
+# Specify path to own LVGL demos config header
+set(LV_DEMO_CONF_PATH
+    ${CMAKE_CURRENT_SOURCE_DIR}/lv_demo_conf.h
+    CACHE STRING "" FORCE)
+
+# Fetch LVGL from GitHub
+FetchContent_Declare(
+    lvgl 
+    GIT_REPOSITORY https://github.com/lvgl/lvgl.git
+)
+
+# Fetch LVGL demos from GitHub
+FetchContent_Declare(
+    lv_demos
+    GIT_REPOSITORY https://github.com/lvgl/lv_demos.git
+)
+
+FetchContent_MakeAvailable(lv_demos lvgl)
+
 
 # select linker script
 set(LINKER_SCRIPT "LinkerScript.ld")
@@ -31,7 +60,6 @@ add_compile_options(
     -fstrict-volatile-bitfields
     -ffunction-sections
     -fdata-sections
-
     -Wall
     -Wshadow
 )
@@ -42,8 +70,6 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/HAL_Driver/Inc
     ${CMAKE_SOURCE_DIR}/CMSIS/device
     ${CMAKE_SOURCE_DIR}/CMSIS/core
-    ${CMAKE_SOURCE_DIR}/lvgl
-    ${CMAKE_SOURCE_DIR}/lv_examples
     ${CMAKE_SOURCE_DIR}/Utilities/STM32746G-Discovery
 )
 
@@ -58,9 +84,6 @@ FILE(GLOB_RECURSE HAL_Sources HAL_Driver/Src/*.c
     Utilities/STM32746G-Discovery/stm32746g_discovery_sdram.c
 )
 FILE(GLOB_RECURSE LVGL_Sources CONFIGURE_DEPENDS hal_stm_lvgl/*.c)
-
-add_subdirectory(lvgl)
-add_subdirectory(lv_demos)
 
 add_definitions(
     -DSTM32
@@ -88,9 +111,8 @@ target_link_libraries(${PROJECT_NAME}
     -nodefaultlibs
     -Wl,--gc-sections
     m
-    lv_demos
-    lvgl
-    # -nostdlib
+    lvgl::demos
+    lvgl::lvgl
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,15 @@ set(LV_DEMO_CONF_PATH
 FetchContent_Declare(
     lvgl 
     GIT_REPOSITORY https://github.com/lvgl/lvgl.git
+    # GIT_TAG release/v8.1    # v8.1.0 - fails as branch CMakeList missing add_library(lvgl::lvgl ALIAS lvgl)
 )
 
 # Fetch LVGL demos from GitHub
 FetchContent_Declare(
     lv_demos
     GIT_REPOSITORY https://github.com/lvgl/lv_demos.git
+    GIT_TAG 615d40f190fe96c9b7d93c3d1dfd36f4acadf7f9    # v8.1.0
+    # GIT_TAG release/v8.1    # v8.1.0 - alternative form
 )
 
 FetchContent_MakeAvailable(lv_demos lvgl)

--- a/hal_stm_lvgl/tft/tft.c
+++ b/hal_stm_lvgl/tft/tft.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 #include "lv_conf.h"
-#include "lvgl/lvgl.h"
+#include "lvgl.h"
 #include <string.h>
 #include <stdlib.h>
 

--- a/hal_stm_lvgl/tft/tft.h
+++ b/hal_stm_lvgl/tft/tft.h
@@ -10,9 +10,8 @@
  *      INCLUDES
  *********************/
 #include <stdint.h>
-#include "lvgl/src/misc/lv_color.h"
-#include "lvgl/src/misc/lv_area.h"
-
+#include "src/misc/lv_color.h"
+#include "src/misc/lv_area.h"
 /*********************
  *      DEFINES
  *********************/

--- a/hal_stm_lvgl/touchpad/touchpad.c
+++ b/hal_stm_lvgl/touchpad/touchpad.c
@@ -7,7 +7,7 @@
  *      INCLUDES
  *********************/
 #include "hal_stm_lvgl/tft/tft.h"
-#include "lvgl/src/hal/lv_hal.h"
+#include "src/hal/lv_hal.h"
 
 #include "stm32746g_discovery.h"
 #include "stm32746g_discovery_ts.h"

--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,11 @@
 
 #include "stm32f7xx.h"
-#include "lvgl/lvgl.h"
+#include "lvgl.h"
 
 #include "hal_stm_lvgl/tft/tft.h"
 #include "hal_stm_lvgl/touchpad/touchpad.h"
 
-#include "lv_demos/lv_demo.h"
+#include "lv_demo.h"
 
 static void SystemClock_Config(void);
 

--- a/src/stm32f7xx_it.c
+++ b/src/stm32f7xx_it.c
@@ -40,7 +40,7 @@
 #include "stm32f7xx_hal.h"
 #include "stm32f7xx_hal_cortex.h"
 
-#include "lvgl/src/hal/lv_hal_tick.h"
+#include "src/hal/lv_hal_tick.h"
 /** @addtogroup STM32F7xx_HAL_Applications
   * @{
   */


### PR DESCRIPTION
The latest update replaces the use of git-submodules with CMake `FetchContent` as covered in the [Lvgl CMake documentation](https://docs.lvgl.io/master/get-started/cmake.html?highlight=cmake)

The submodules haven't been removed for legacy support - Assuming PR is accepted then look to remove submodule dependency.

The major change is to header include paths. When using `FetchContent` the include path is resolved to `lvgl` and `lv_demos`. So, for example, the `#include` in `main.c` is changed from
```
 #include "lvgl/lvgl.h"
```
to
```
#include "lvgl.h"
```

Tested on:
* Ubuntu 21.04/20.04
* macOS native
* macOS devcontainer
* Win10 devcontainer
* WSL2 devcontainer

## Lvgl v8.1 bug
The CMakeFiles.txt used for v8.1 doesn't correctly set up the library dependency for lvgl::lvgl. This means the `FetchContent` can't pull based on the hash or tag of `version/8.1`. Currently, it pulls the latest commit of Lvgl.